### PR TITLE
Docker environment to easily run code as external collaborator

### DIFF
--- a/build_and_start_docker.sh
+++ b/build_and_start_docker.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# build image
+IMAGE_NAME=pde
+docker build -t ${IMAGE_NAME} ./docker
+
+# run container
+WORKDIR_NATIVE=$(pwd)
+WORKDIR_DOCKER=/opt/workdir  # doesn't really matter
+docker run --rm -it \
+    -v ${WORKDIR_NATIVE}:${WORKDIR_DOCKER} \
+    -w ${WORKDIR_DOCKER} \
+    $IMAGE_NAME /bin/bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM continuumio/miniconda3
+
+# core libraries
+RUN pip install --no-cache-dir \
+    tensorflow==1.13.1 \
+    absl-py apache-beam numpy xarray \
+    scikit-learn matplotlib jupyterlab
+
+# protobuf compiler
+RUN conda install -y protobuf && \
+    conda clean -afy

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM continuumio/miniconda3
 
 # core libraries
 RUN pip install --no-cache-dir \
-    tensorflow==1.13.1 \
+    tensorflow==1.14.0rc1 \
     absl-py apache-beam numpy xarray \
     scikit-learn matplotlib jupyterlab
 

--- a/pde_superresolution_2d/core/tensor_ops.py
+++ b/pde_superresolution_2d/core/tensor_ops.py
@@ -184,7 +184,7 @@ def extract_patches_2d(
 
   size_x, size_y = kernel_size
   extracted = tf.extract_image_patches(padded[..., tf.newaxis],
-                                       sizes=[1, size_x, size_y, 1],
+                                       ksizes=[1, size_x, size_y, 1],
                                        strides=[1, 1, 1, 1],
                                        rates=[1, 1, 1, 1],
                                        padding='VALID')

--- a/pde_superresolution_2d/pipelines/create_training_data.py
+++ b/pde_superresolution_2d/pipelines/create_training_data.py
@@ -36,7 +36,7 @@ import tensorflow as tf
 from pde_superresolution_2d.advection import equations as advection_equations
 # pylint: enable=unused-import,g-bad-import-order
 
-from apache_beam import runner as flume_runner
+from apache_beam import runners as flume_runner
 
 # our beam pipeline requires eager mode
 tf.enable_eager_execution()

--- a/run_tests_in_docker.sh
+++ b/run_tests_in_docker.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Run this script inside Docker container
+
+# Install this packgae
+pip install -e .  # track source code change
+
+# compile protobuf
+SRC_DIR=./pde_superresolution_2d
+protoc -I=$SRC_DIR --python_out=$SRC_DIR $SRC_DIR/metadata.proto
+
+# Run tests
+# TODO: use Bazel to run all tests instead of manually discovering tests
+test_files=$(find . -name '*_test.py')
+log_file=testing_$(date '+%Y-%m-%d_%H:%M:%S').log
+for file in $test_files; do
+    # echo $file
+    python $file 2>&1 | tee -a $log_file
+done
+


### PR DESCRIPTION
@yohai give it a try? It should run out-of-box.

Steps:
1. [Install docker](https://docs.docker.com/install/)
2. Run `build_and_start_docker.sh` to start the container (will take a while to build at the first time)
3. Inside container, run `run_tests_in_docker.sh` to execute all tests 

It passes all tests, except a few non-advection experimental code. Log file: [testing_2019-06-11_07_34_47.log](https://github.com/googleprivate/pde-superresolution-2d/files/3278573/testing_2019-06-11_07_34_47.log)

Other comments:
- On local machines, Apache Beam doesn't seem to bring much benefit. My understanding is that Beam is map-reduce framework for embarrassingly parallel tasks on a big cloud cluster. Might be useful to have an alternative integration test without beam dependency. 
- Not sure how to sync external PR with internal code. Should probably always commit to internal repo and then export to GitHub.
- The container image only works on CPU. Might try [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) for GPU.
