### PR TITLE
Remove apache-beam from dependencies to prevent Colab install error

### DIFF
--- a/datadrivenpdes/__init__.py
+++ b/datadrivenpdes/__init__.py
@@ -1,4 +1,3 @@
 """2D PDE superresolution models."""
 from datadrivenpdes import advection
 from datadrivenpdes import core
-from datadrivenpdes import pipelines

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ import setuptools
 
 INSTALL_REQUIRES = [
     'absl-py',
-    'apache-beam',
     'numpy',
     'scipy',
     'xarray',


### PR DESCRIPTION
When installing this package in Colab via `!pip install git+https://github.com/google-research/data-driven-pdes.git`, I got 
```
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```
due to the `apache-beam` dependency.

See this notebook for the complete install error:
https://colab.research.google.com/drive/1UbKevNe8BIPExuBdiqW3ZWy58Lh6E1gk

Since the beam pipeline is rarely used in notebook anyways, I just removed the beam dependency to fix the problem.